### PR TITLE
Add end-to-end integration test for the indexing pipeline

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,10 @@
 {
   "presets": [
     "@babel/preset-env"
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-runtime"]
+    }
+  }
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,27 +16,36 @@ jobs:
       CC_TEST_REPORTER_ID: df07c492e87437bdb4127915ce554fd0b601e9111d66119ebfaa73eba57d5cf4
     steps:
       - checkout
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
+      - setup_remote_docker
       - restore_cache:
           keys:
             - dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - dependencies-
-      - run: npm install
+      - run:
+          name: Install dependencies
+          command: npm install
       - save_cache:
           paths:
             - node_modules
           key: dependencies-{{ checksum "package.json" }}
       - run:
-          name: Run tests
+          name: Spin up containers for integration testing
+          command: docker-compose up -d pipeline platform
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
+          name: Lint and run unit tests
           command: |
             ./cc-test-reporter before-build
             npm run ci
             ./cc-test-reporter after-build --exit-code $?
+      - run:
+          name: Run integration tests
+          command: docker-compose up integration
   register_image:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             ./cc-test-reporter after-build --exit-code $?
       - run:
           name: Spin up containers for integration testing
-          command: docker-compose up -d pipeline platform
+          command: docker-compose up -d pipeline
       - run:
           name: Run integration tests
           command: docker-compose up integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,6 @@ jobs:
             - node_modules
           key: dependencies-{{ checksum "package.json" }}
       - run:
-          name: Spin up containers for integration testing
-          command: docker-compose up -d pipeline platform
-      - run:
           name: Setup Code Climate test-reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -43,6 +40,9 @@ jobs:
             ./cc-test-reporter before-build
             npm run ci
             ./cc-test-reporter after-build --exit-code $?
+      - run:
+          name: Spin up containers for integration testing
+          command: docker-compose up -d pipeline platform
       - run:
           name: Run integration tests
           command: docker-compose up integration

--- a/.eslintrc-todo.yml
+++ b/.eslintrc-todo.yml
@@ -4,3 +4,8 @@ overrides:
       no-global-assign: off
     files:
       - runner.js
+  -
+    rules:
+      no-extra-boolean-cast: off
+    files:
+      - __tests__/pipeline.integration.js

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ To run the integration tests, they must be invoked independent of the unit tests
 $ npm run integration
 ```
 
-You may also run these in a container to more closely mimic the behavior running in continuous integration:
+### Continuous Integration
+
+We are using CircleCI to run continuous integration. CircleCI invokes the integration tests using a container, which works around inter-container networking constraints in the CI environment. If you prefer to run integration tests in a manner that more closely matches what runs in CI, you can do that via:
 
 ```shell
 $ docker-compose up integration

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ $ docker-compose down
 To create a Trellis resource and test integration between the pipeline components, you may do so using a curl incantation like follows:
 
 ```shell
-curl -i -X POST -H 'Content-Type: text/turtle; charset=UTF-8' -H 'Link: <http://www.w3.org/ns/ldp#BasicContainer>; rel="type"' -H "Slug: $(uuidgen)" -d "@prefix dcterms: <http://purl.org/dc/terms/> .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n<> a ldp:Container, ldp:BasicContainer;\n dcterms:title 'A cool resource' ." http://platform:8080
+curl -i -X POST -H 'Content-Type: text/turtle; charset=UTF-8' -H 'Link: <http://www.w3.org/ns/ldp#BasicContainer>; rel="type"' -H "Slug: $(uuidgen)" -d "@prefix dcterms: <http://purl.org/dc/terms/> .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n<> a ldp:Container, ldp:BasicContainer;\n dcterms:title 'A cool resource' ." http://localhost:8080
 ```
-
-Note that the above example assumes that your host has an alias from `platform` (the name of Trellis host running within docker-compose) to `localhost` (in e.g., `/etc/hosts`). If you use `localhost:8080` instead, the pipeline won't be able to retrieve the resource from Trellis.
 
 ## Development
 
@@ -49,10 +47,6 @@ npm run dev-start
 ```
 
 Note that if you want to view the ElasticSearch index, you can browse to http://localhost:1358/.
-
-### Create a Trellis resource (dev)
-
-See the same section under `Testing` above, but note that you won't need to create the `platform` alias when running in dev, so your `curl` command can hit `localhost:8080`.
 
 ## Build and push image
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the repository for the Sinopia Indexing Pipeline. The pipeline is a Node
 Using `docker-compose`, you can spin up containers for Trellis, ActiveMQ, ElasticSearch, Postgres, and the pipeline::
 
 ```shell
-$ docker-compose up -d
+$ docker-compose up -d pipeline
 ```
 
 To shut it down and clean up, run:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that the above example assumes that your host has an alias from `platform` 
 For development purposes, you may wish to spin up all the components other than the pipeline if you'll be iterating:
 
 ```shell
-$ docker-compose up -d platform search
+$ docker-compose up -d platform search searchui
 ```
 
 And then spin up the pipeline using:
@@ -47,6 +47,8 @@ And then spin up the pipeline using:
 ```shell
 npm run dev-start
 ```
+
+Note that if you want to view the ElasticSearch index, you can browse to http://localhost:1358/.
 
 ### Create a Trellis resource (dev)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,31 @@ To shut it down and clean up, run:
 $ docker-compose down
 ```
 
+### Run the linter and tests
+
+```shell
+$ npm run ci
+```
+
+Or, to run the linter and unit tests separately:
+
+```shell
+$ npm run lint
+$ npm test
+```
+
+To run the integration tests, they must be invoked independent of the unit tests:
+
+```shell
+$ npm run integration
+```
+
+You may also run these in a container to more closely mimic the behavior running in continuous integration:
+
+```shell
+$ docker-compose up integration
+```
+
 ### Create a Trellis resource (test)
 
 To create a Trellis resource and test integration between the pipeline components, you may do so using a curl incantation like follows:

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -4,6 +4,9 @@ const OLD_ENV = process.env
 
 describe('Config', () => {
   describe('with default values', () => {
+    test('platformUrl has default value', () => {
+      expect(Config.platformUrl).toEqual('http://platform:8080')
+    })
     test('brokerHost has default value', () => {
       expect(Config.brokerHost).toEqual('localhost')
     })
@@ -36,6 +39,7 @@ describe('Config', () => {
     // Strategy for stubbing `process.env`: https://stackoverflow.com/a/48042799
     beforeEach(() => {
       process.env = {
+        TRELLIS_BASE_URL: 'https://ldp.example.edu',
         BROKER_HOST: 'myhost',
         BROKER_PORT: 61616,
         QUEUE_NAME: '/topic/foobar',
@@ -49,6 +53,9 @@ describe('Config', () => {
     })
     afterEach(() => {
       process.env = OLD_ENV
+    })
+    test('platformUrl has overridden value', () => {
+      expect(Config.platformUrl).toEqual('https://ldp.example.edu')
     })
     test('brokerHost has overridden value', () => {
       expect(Config.brokerHost).toEqual('myhost')

--- a/__tests__/indexer.test.js
+++ b/__tests__/indexer.test.js
@@ -20,7 +20,7 @@ describe('Indexer', () => {
   describe('index()', () => {
     let clientMock = new IndexerSuccessFake()
     let indexSpy = jest.spyOn(clientMock, 'index')
-    let json = JSON.stringify({ foo: 'bar' })
+    let json = { '@id': '12345', foo: 'bar' }
 
     beforeEach(() => {
       indexer.client = clientMock
@@ -30,6 +30,7 @@ describe('Indexer', () => {
       expect(indexSpy).toHaveBeenCalledWith({
         index: Config.indexName,
         type: Config.indexType,
+        id: '12345',
         body: json
       })
     })

--- a/__tests__/pipeline.integration.js
+++ b/__tests__/pipeline.integration.js
@@ -50,7 +50,7 @@ describe('integration tests', () => {
       .then(res => res.body)
 
     // Give the pipeline a chance to run
-    await sleep(3000)
+    await sleep(4500)
 
     return client.search({
       index: Config.indexName,

--- a/__tests__/pipeline.integration.js
+++ b/__tests__/pipeline.integration.js
@@ -10,6 +10,8 @@ describe('integration tests', () => {
   const resourceSlug = Math.floor(Math.random() * 1000000).toString()
   const resourceId = `${Config.platformUrl}/${resourceSlug}`
   const resourceTitle = 'A cool title'
+  // Use localhost if not in container, else use configured value
+  const trellisEndpoint = Boolean(process.env.INSIDE_CONTAINER) ? Config.platformUrl : 'http://localhost:8080'
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
   beforeAll(() => {
@@ -40,7 +42,7 @@ describe('integration tests', () => {
     })
   })
   test('new Trellis resource is indexed as expected', async () => {
-    superagent.post(Config.platformUrl)
+    superagent.post(trellisEndpoint)
       .type('text/turtle; charset=UTF-8')
       .send(`@prefix dcterms: <http://purl.org/dc/terms/> .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n<> a ldp:BasicContainer;\n dcterms:title '${resourceTitle}' .`)
       .set('Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
@@ -48,7 +50,7 @@ describe('integration tests', () => {
       .then(res => res.body)
 
     // Give the pipeline a chance to run
-    await sleep(2000)
+    await sleep(3000)
 
     return client.search({
       index: Config.indexName,

--- a/__tests__/pipeline.integration.js
+++ b/__tests__/pipeline.integration.js
@@ -1,0 +1,72 @@
+import elasticsearch from 'elasticsearch'
+import superagent from 'superagent'
+import Config from '../src/config'
+
+describe('integration tests', () => {
+  const client = new elasticsearch.Client({
+    host: `${Config.indexHost}:${Config.indexPort}`,
+    log: 'debug'
+  })
+  const resourceSlug = Math.floor(Math.random() * 1000000).toString()
+  const resourceId = `${Config.platformUrl}/${resourceSlug}`
+  const resourceTitle = 'A cool title'
+  const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+  beforeAll(() => {
+    return client.indices.create({
+      index: Config.indexName
+    })
+  })
+  afterAll(() => {
+    return client.indices.delete({
+      index: Config.indexName
+    })
+  })
+  test('index is clear of test document', () => {
+    return client.search({
+      index: Config.indexName,
+      type: Config.indexType,
+      body: {
+        query: {
+          term: {
+            _id: {
+              value: resourceId
+            }
+          }
+        }
+      }
+    }).then(response => {
+      expect(response.hits.total).toEqual(0)
+    })
+  })
+  test('new Trellis resource is indexed as expected', async () => {
+    superagent.post(Config.platformUrl)
+      .type('text/turtle; charset=UTF-8')
+      .send(`@prefix dcterms: <http://purl.org/dc/terms/> .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n<> a ldp:BasicContainer;\n dcterms:title '${resourceTitle}' .`)
+      .set('Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
+      .set('Slug', resourceSlug)
+      .then(res => res.body)
+
+    // Give the pipeline a chance to run
+    await sleep(2000)
+
+    return client.search({
+      index: Config.indexName,
+      type: Config.indexType,
+      body: {
+        query: {
+          term: {
+            _id: {
+              value: resourceId
+            }
+          }
+        }
+      }
+    }).then(response => {
+      expect(response.hits.total).toEqual(1)
+      let firstHit = response.hits.hits[0]
+      expect(firstHit._source['@id']).toEqual(resourceId)
+      expect(firstHit._source.title).toEqual(resourceTitle)
+    })
+  })
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,21 @@ services:
     environment:
       INDEX_HOST: search
       BROKER_HOST: broker
-    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 180s npm start
+    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 2m npm start
     depends_on:
       - broker
       - search
+  integration:
+    build:
+      context: .
+    environment:
+      INDEX_HOST: search
+      BROKER_HOST: broker
+    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -wait tcp://platform:8080 -timeout 2m npm run integration
+    depends_on:
+      - broker
+      - search
+      - platform
   database:
     image: postgres:latest
     environment:
@@ -45,6 +56,8 @@ services:
       - -Ehttp.cors.allow-origin=http://searchui:1358,http://localhost:1358,http://127.0.0.1:1358
       - -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
       - -Ehttp.cors.allow-credentials=true
+      - -Etransport.host=localhost
+      - -Ebootstrap.system_call_filter=false
     user: elasticsearch
     ports:
       - 9200:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       INDEX_HOST: search
       BROKER_HOST: broker
-    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 2m npm start
+    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 3m npm start
     depends_on:
       - broker
       - search
@@ -33,7 +33,8 @@ services:
     environment:
       INDEX_HOST: search
       BROKER_HOST: broker
-    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -wait tcp://platform:8080 -timeout 2m npm run integration
+      INSIDE_CONTAINER: 'true'
+    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -wait tcp://platform:8080 -timeout 3m npm run integration
     depends_on:
       - broker
       - search

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     depends_on:
       - broker
       - search
+      - platform
   integration:
     build:
       context: .
@@ -36,9 +37,7 @@ services:
       INSIDE_CONTAINER: 'true'
     command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -wait tcp://platform:8080 -timeout 3m npm run integration
     depends_on:
-      - broker
-      - search
-      - platform
+      - pipeline
   database:
     image: postgres:latest
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - 8161:8161
   platform:
     image: ld4p/trellis-ext-db:latest
+    environment:
+      TRELLIS_BASE_URL: http://platform:8080
     ports:
       - 8080:8080
       - 8081:8081
@@ -21,7 +23,7 @@ services:
     environment:
       INDEX_HOST: search
       BROKER_HOST: broker
-    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 120s npm start
+    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 180s npm start
     depends_on:
       - broker
       - search
@@ -36,9 +38,23 @@ services:
       - 5432:5432
   search:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    entrypoint:
+      - elasticsearch
+      - -Ehttp.port=9200
+      - -Ehttp.cors.enabled=true
+      - -Ehttp.cors.allow-origin=http://searchui:1358,http://localhost:1358,http://127.0.0.1:1358
+      - -Ehttp.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
+      - -Ehttp.cors.allow-credentials=true
+    user: elasticsearch
     ports:
       - 9200:9200
       - 9300:9300
+  searchui:
+    image: appbaseio/dejavu:latest
+    ports:
+      - 1358:1358
+    depends_on:
+      - search
   migration:
     image: ld4p/trellis-ext-db:latest
     command: ["/opt/trellis/bin/trellis-db", "db", "migrate", "/opt/trellis/etc/config.yml"]

--- a/jest.config.js
+++ b/jest.config.js
@@ -150,7 +150,9 @@ module.exports = {
   // ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  // testRegex: [],
+  testRegex: [
+    '\\.test\\.js$'
+  ],
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -620,6 +620,18 @@
         "regenerator-transform": "^0.13.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz",
+      "integrity": "sha512-PaoARuztAdd5MgeVjAxnIDAIUet5KpogqaefQvPOmPYCxYoaPhautxDh3aO8a4xHsKgT/b9gSxR0BKK1MIewPA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -752,6 +764,14 @@
         "mkdirp": "^0.5.1",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.9"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "@babel/template": {
@@ -6304,8 +6324,7 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "ci": "npm run lint && npm run coverage",
     "coverage": "jest --color --coverage",
     "dev-start": "nodemon --exec babel-node runner.js",
+    "integration": "jest --color --testRegex=\\.integration\\.js$",
     "lint": "eslint --color -c .eslintrc.yml --ext js .",
     "start": "babel-node runner.js",
     "test": "jest --color"
   },
   "dependencies": {
+    "@babel/runtime": "^7.3.4",
     "elasticsearch": "^15.4.1",
     "stomp-client": "^0.9.0",
     "superagent": "^4.1.0"
@@ -27,6 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.3.3",
     "@babel/node": "^7.2.2",
+    "@babel/plugin-transform-runtime": "^7.3.4",
     "@babel/preset-env": "^7.3.1",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,8 @@
 export default class Config {
+  static get platformUrl() {
+    return process.env.TRELLIS_BASE_URL || 'http://platform:8080'
+  }
+
   static get brokerHost() {
     return process.env.BROKER_HOST || 'localhost'
   }

--- a/src/indexer.js
+++ b/src/indexer.js
@@ -20,6 +20,7 @@ export default class Indexer {
     return this.client.index({
       index: Config.indexName,
       type: Config.indexType,
+      id: json['@id'],
       body: json
     }).then(indexResponse => {
       if (indexResponse.result != 'created') {


### PR DESCRIPTION
This branch adds the end-to-end integration test for the indexing pipeline and includes work on supporting issues, including:

* Use resource identifier as index document identifier for easier retrieval later
* Use DejaVu as ElasticSearch UI: this helps in development, providing an easy, visual means of inspecting what the pipeline is doing behind the scenes.
* Use `@babel/runtime` and associated plugin to support `async`/`await` in Jest test suite
* Use `docker-compose` in CI (for integration test)
* Update `Config` class and test to allow platform URL to be specified via environment variable
* Use jest `testRegex` configuration value to keep unit and integration tests separate (and run units by default)
* Add `integration` script to run integration tests separate from `npm test`

Fixes #5
Fixes #6
Fixes #7
