### PR TITLE
Remove CC reporter ID from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ version: 2
 jobs:
   build:
     <<: *defaults
-    environment:
-      CC_TEST_REPORTER_ID: df07c492e87437bdb4127915ce554fd0b601e9111d66119ebfaa73eba57d5cf4
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Prefer storing this in the CircleCI dashboard instead.