### PR TITLE
Use only path portion of Trellis URIs as ES identifiers

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -7,6 +7,9 @@ describe('Config', () => {
     test('platformUrl has default value', () => {
       expect(Config.platformUrl).toEqual('http://platform:8080')
     })
+    test('rootNodeIdentifier has default value', () => {
+      expect(Config.rootNodeIdentifier).toEqual('__root_node__')
+    })
     test('brokerHost has default value', () => {
       expect(Config.brokerHost).toEqual('localhost')
     })
@@ -40,6 +43,7 @@ describe('Config', () => {
     beforeEach(() => {
       process.env = {
         TRELLIS_BASE_URL: 'https://ldp.example.edu',
+        ROOT_NODE_IDENTIFIER: 'super_cool',
         BROKER_HOST: 'myhost',
         BROKER_PORT: 61616,
         QUEUE_NAME: '/topic/foobar',
@@ -56,6 +60,9 @@ describe('Config', () => {
     })
     test('platformUrl has overridden value', () => {
       expect(Config.platformUrl).toEqual('https://ldp.example.edu')
+    })
+    test('rootNodeIdentifier has overridden value', () => {
+      expect(Config.rootNodeIdentifier).toEqual('super_cool')
     })
     test('brokerHost has overridden value', () => {
       expect(Config.brokerHost).toEqual('myhost')

--- a/__tests__/indexer.test.js
+++ b/__tests__/indexer.test.js
@@ -32,7 +32,7 @@ describe('Indexer', () => {
   describe('index()', () => {
     let clientMock = new ClientSuccessFake()
     let indexSpy = jest.spyOn(clientMock, 'index')
-    let json = { '@id': '12345', foo: 'bar' }
+    let json = { '@id': 'http://foo.bar/12345', foo: 'bar' }
 
     beforeAll(() => {
       indexer.client = clientMock
@@ -43,7 +43,7 @@ describe('Indexer', () => {
       restoreConsole()
     })
     test('calls index() on the client', () => {
-      indexer.index(json, '12345')
+      indexer.index(json, 'http://foo.bar/12345')
       expect(indexSpy).toHaveBeenCalledWith({
         index: Config.indexName,
         type: Config.indexType,
@@ -90,7 +90,7 @@ describe('Indexer', () => {
   describe('delete()', () => {
     let clientMock = new ClientSuccessFake()
     let deleteSpy = jest.spyOn(clientMock, 'delete')
-    let uri = '12345'
+    let uri = 'http://foo.bar/12345'
 
     beforeEach(() => {
       indexer.client = clientMock
@@ -107,7 +107,7 @@ describe('Indexer', () => {
       expect(deleteSpy).toHaveBeenCalledWith({
         index: Config.indexName,
         type: Config.indexType,
-        id: uri
+        id: '12345'
       })
     })
     describe('when delete succeeds', () => {
@@ -143,6 +143,23 @@ describe('Indexer', () => {
         expect.assertions(1)
         await indexer.delete(uri)
         expect(logSpy).toHaveBeenCalledWith('error deleting: what a useful error message this is')
+      })
+    })
+  })
+  describe('identifier_from()', () => {
+    beforeAll(() => {
+      // Eat console output
+      restoreConsole = mockConsole(['error', 'debug'])
+    })
+    afterAll(() => {
+      restoreConsole()
+    })
+    test('removes URI scheme/host/port', () => {
+      expect(indexer.identifier_from('https://localhost:8080/one-two-three')).toBe('one-two-three')
+    })
+    describe('with a pathless URI', () => {
+      test('returns pre-configured value', () => {
+        expect(indexer.identifier_from('https://localhost:8080/')).toBe(Config.rootNodeIdentifier)
       })
     })
   })

--- a/__tests__/pipeline.integration.js
+++ b/__tests__/pipeline.integration.js
@@ -7,7 +7,7 @@ describe('integration tests', () => {
     host: `${Config.indexHost}:${Config.indexPort}`,
     log: 'warning'
   })
-  const resourceSlug = Math.floor(Math.random() * 1000000).toString()
+  const resourceSlug = 'resourceTemplate:foo123:Something:Excellent'
   const resourceId = `${Config.platformUrl}/${resourceSlug}`
   const resourceTitle = 'A cool title'
   // Use localhost if not in container, else use configured value
@@ -28,7 +28,7 @@ describe('integration tests', () => {
     return client.delete({
       index: Config.indexName,
       type: Config.indexType,
-      id: resourceId
+      id: resourceSlug
     })
   })
   test('index is clear of test document', () => {
@@ -39,7 +39,7 @@ describe('integration tests', () => {
         query: {
           term: {
             _id: {
-              value: resourceId
+              value: resourceSlug
             }
           }
         }
@@ -66,7 +66,7 @@ describe('integration tests', () => {
         query: {
           term: {
             _id: {
-              value: resourceId
+              value: resourceSlug
             }
           }
         }
@@ -92,7 +92,7 @@ describe('integration tests', () => {
         query: {
           term: {
             _id: {
-              value: resourceId
+              value: resourceSlug
             }
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6236,6 +6236,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
       "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
+    "querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6500,6 +6505,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.10.0",
@@ -7792,6 +7802,15 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "url-parse-lax": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@babel/runtime": "^7.3.4",
     "elasticsearch": "^15.4.1",
     "stomp-client": "^0.9.0",
-    "superagent": "^4.1.0"
+    "superagent": "^4.1.0",
+    "url-parse": "^1.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,10 @@ export default class Config {
     return process.env.TRELLIS_BASE_URL || 'http://platform:8080'
   }
 
+  static get rootNodeIdentifier() {
+    return process.env.ROOT_NODE_IDENTIFIER || '__root_node__'
+  }
+
   static get brokerHost() {
     return process.env.BROKER_HOST || 'localhost'
   }


### PR DESCRIPTION
This will allow sinopia_editor to ask ES for specific resource templates, presuming the editor is aware of the template identifier, without having to pass around knowledge of where/how Trellis is running

connects to LD4P/sinopia_editor#309