### PR TITLE
Distinguish between RDF and non-RDF resource when indexing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 
 defaults: &defaults
   docker:
-    - image: circleci/node:10.11-browsers
+    - image: circleci/node:10.15.3
   working_directory: ~/sinopia_indexing_pipeline
 
 version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM circleci/node:10.11
+FROM circleci/node:10.15.3
 
 WORKDIR /home/circleci
 
 COPY . .
 
 RUN npm install
+
+CMD ["npm", "start"]

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -22,17 +22,26 @@ describe('Config', () => {
     test('defaultMimeType has default value', () => {
       expect(Config.defaultMimeType).toEqual('application/ld+json')
     })
-    test('indexName has default value', () => {
-      expect(Config.indexName).toEqual('sinopia_index')
+    test('resourceIndexName has default value', () => {
+      expect(Config.resourceIndexName).toEqual('sinopia_resources')
+    })
+    test('nonRdfIndexName has default value', () => {
+      expect(Config.nonRdfIndexName).toEqual('sinopia_templates')
     })
     test('indexType has default value', () => {
-      expect(Config.indexType).toEqual('sinopia_resource')
+      expect(Config.indexType).toEqual('sinopia')
     })
     test('indexHost has default value', () => {
       expect(Config.indexHost).toEqual('localhost')
     })
     test('indexPort has default value', () => {
       expect(Config.indexPort).toEqual(9200)
+    })
+    test('nonRdfTypeURI has default value', () => {
+      expect(Config.nonRdfTypeURI).toEqual('http://www.w3.org/ns/ldp#NonRDFSource')
+    })
+    test('nonRdfMimeType has default value', () => {
+      expect(Config.nonRdfMimeType).toEqual('application/json')
     })
     test('debug has default value', () => {
       expect(Config.debug).toEqual(true)
@@ -48,10 +57,13 @@ describe('Config', () => {
         BROKER_PORT: 61616,
         QUEUE_NAME: '/topic/foobar',
         DEFAULT_MIME_TYPE: 'text/plain',
-        INDEX_NAME: 'test',
+        RESOURCE_INDEX_NAME: 'test',
         INDEX_TYPE: 'other',
+        NON_RDF_INDEX_NAME: 'test2',
         INDEX_HOST: 'otherhost',
         INDEX_PORT: 9300,
+        NON_RDF_TYPE_URI: 'http://foo.example.org/bar',
+        NON_RDF_MIME_TYPE: 'text/plain',
         DEBUG: false
       }
     })
@@ -67,28 +79,37 @@ describe('Config', () => {
     test('brokerHost has overridden value', () => {
       expect(Config.brokerHost).toEqual('myhost')
     })
-    test('brokerPort has default value', () => {
+    test('brokerPort has overridden value', () => {
       expect(Config.brokerPort).toEqual(61616)
     })
-    test('queueName has default value', () => {
+    test('queueName has overridden value', () => {
       expect(Config.queueName).toEqual('/topic/foobar')
     })
-    test('defaultMimeType has default value', () => {
+    test('defaultMimeType has overridden value', () => {
       expect(Config.defaultMimeType).toEqual('text/plain')
     })
-    test('indexName has default value', () => {
-      expect(Config.indexName).toEqual('test')
+    test('resourceIndexName has overridden value', () => {
+      expect(Config.resourceIndexName).toEqual('test')
     })
-    test('indexType has default value', () => {
+    test('nonRdfIndexName has overridden value', () => {
+      expect(Config.nonRdfIndexName).toEqual('test2')
+    })
+    test('indexType has overridden value', () => {
       expect(Config.indexType).toEqual('other')
     })
-    test('indexHost has default value', () => {
+    test('indexHost has overridden value', () => {
       expect(Config.indexHost).toEqual('otherhost')
     })
-    test('indexPort has default value', () => {
+    test('indexPort has overridden value', () => {
       expect(Config.indexPort).toEqual(9300)
     })
-    test('debug has default value', () => {
+    test('nonRdfTypeURI has overridden value', () => {
+      expect(Config.nonRdfTypeURI).toEqual('http://foo.example.org/bar')
+    })
+    test('nonRdfMimeType has overridden value', () => {
+      expect(Config.nonRdfMimeType).toEqual('text/plain')
+    })
+    test('debug has overridden value', () => {
       expect(Config.debug).toEqual(false)
     })
   })

--- a/__tests__/listener.test.js
+++ b/__tests__/listener.test.js
@@ -11,7 +11,7 @@ import BrokerFake from '../__mocks__/broker-fake'
 let restoreConsole = null
 
 describe('Listener', () => {
-  let listener = new Listener()
+  const listener = new Listener()
 
   describe('constructor', () => {
     test('sets this.logger', () => {
@@ -22,8 +22,8 @@ describe('Listener', () => {
     })
   })
   describe('listen()', () => {
-    let newMessageHandler = jest.fn()
-    let logSpy = jest.spyOn(listener.logger, 'debug')
+    const newMessageHandler = jest.fn()
+    const logSpy = jest.spyOn(listener.logger, 'debug')
 
     beforeEach(() => {
       listener.client = new BrokerFake(Config.brokerHost, Config.brokerPort)
@@ -40,7 +40,7 @@ describe('Listener', () => {
       expect(logSpy).toHaveBeenCalledWith(`connecting to stomp at ${Config.brokerHost}:${Config.brokerPort}`)
     })
     test('calls connect on the client', () => {
-      let clientSpy = jest.spyOn(listener.client, 'connect')
+      const clientSpy = jest.spyOn(listener.client, 'connect')
 
       listener.listen(newMessageHandler)
       expect(clientSpy).toHaveBeenCalledTimes(1)
@@ -50,7 +50,7 @@ describe('Listener', () => {
       expect(logSpy).toHaveBeenCalledWith(`subscribing to ${Config.queueName}, waiting for messages`)
     })
     test('subscribes to specified queue with given callback', () => {
-      let clientSpy = jest.spyOn(listener.client, 'subscribe')
+      const clientSpy = jest.spyOn(listener.client, 'subscribe')
 
       listener.listen(newMessageHandler)
       expect(clientSpy).toHaveBeenCalledWith(Config.queueName, newMessageHandler)

--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -9,7 +9,7 @@ describe('Logger', () => {
   const logger = new Logger()
 
   describe('debug', () => {
-    let consoleSpy = jest.spyOn(console, 'debug')
+    const consoleSpy = jest.spyOn(console, 'debug')
 
     beforeEach(() => {
       consoleSpy.mockReset()
@@ -34,7 +34,7 @@ describe('Logger', () => {
     })
   })
   describe('error', () => {
-    let consoleSpy = jest.spyOn(console, 'error')
+    const consoleSpy = jest.spyOn(console, 'error')
 
     beforeEach(() => {
       consoleSpy.mockReset()

--- a/__tests__/pipeline.test.js
+++ b/__tests__/pipeline.test.js
@@ -26,7 +26,7 @@ import ClientSuccessFake from '../__mocks__/client-success-fake'
 let restoreConsole = null
 
 describe('Pipeline', () => {
-  let pipeline = new Pipeline()
+  const pipeline = new Pipeline()
 
   describe('constructor', () => {
     test('sets this.listener', () => {
@@ -39,13 +39,23 @@ describe('Pipeline', () => {
       expect(pipeline.indexer).toBeInstanceOf(Indexer)
     })
   })
+  describe('mimeTypeFrom()', () => {
+    test('returns the default mime type by default', () => {
+      expect(pipeline.mimeTypeFrom([])).toBe('application/ld+json')
+    })
+    test('returns the non RDF mime type when types includes LDP-NRS', () => {
+      expect(pipeline.mimeTypeFrom(['http://www.w3.org/ns/ldp#NonRDFSource'])).toBe('application/json')
+    })
+  })
   describe('run()', () => {
-    let logSpy = jest.spyOn(pipeline.logger, 'debug')
-    let errorSpy = jest.spyOn(pipeline.logger, 'error')
-    let objectUri = 'http://example.org/foo'
-    let fakeBody = JSON.stringify({
+    const logSpy = jest.spyOn(pipeline.logger, 'debug')
+    const errorSpy = jest.spyOn(pipeline.logger, 'error')
+    const objectUri = 'http://example.org/foo'
+    const objectTypes = ['http://www.w3.org/ns/ldp#BasicContainer']
+    const fakeBody = JSON.stringify({
       object: {
-        id: objectUri
+        id: objectUri,
+        type: objectTypes
       },
       type: [
         'this is usually a PROV URI in string form but our code does not care',
@@ -64,7 +74,7 @@ describe('Pipeline', () => {
       restoreConsole()
     })
     test('listens for messages', () => {
-      let listenerSpy = jest.spyOn(pipeline.listener, 'listen')
+      const listenerSpy = jest.spyOn(pipeline.listener, 'listen')
 
       pipeline.run()
       expect(listenerSpy).toHaveBeenCalledTimes(1)
@@ -87,9 +97,10 @@ describe('Pipeline', () => {
       })
     })
     describe('when handling deletes', () => {
-      let fakeBody = JSON.stringify({
+      const fakeBody = JSON.stringify({
         object: {
-          id: objectUri
+          id: objectUri,
+          type: objectTypes
         },
         type: [
           'this is usually a PROV URI in string form but our code does not care',
@@ -105,15 +116,16 @@ describe('Pipeline', () => {
         expect(logSpy).toHaveBeenCalledWith(`deleting ${objectUri} from index`)
       })
       test('calls delete on the indexer', () => {
-        let indexerSpy = jest.spyOn(pipeline.indexer, 'delete')
+        const indexerSpy = jest.spyOn(pipeline.indexer, 'delete')
         pipeline.run()
-        expect(indexerSpy).toHaveBeenCalledWith(objectUri)
+        expect(indexerSpy).toHaveBeenCalledWith(objectUri, objectTypes)
       })
     })
     describe('when handling unsupported operations', () => {
-      let fakeBody = JSON.stringify({
+      const fakeBody = JSON.stringify({
         object: {
-          id: objectUri
+          id: objectUri,
+          type: objectTypes
         },
         type: [
           'this is usually a PROV URI in string form but our code does not care',

--- a/__tests__/request.test.js
+++ b/__tests__/request.test.js
@@ -12,8 +12,8 @@ import AgentFailureFake from '../__mocks__/agent-failure-fake'
 let restoreConsole = null
 
 describe('Request', () => {
-  let uri = 'http://example.edu/foo'
-  let request = new Request(uri)
+  const uri = 'http://example.edu/foo'
+  const request = new Request(uri)
 
   describe('constructor', () => {
     test('sets this.uri', () => {
@@ -30,7 +30,7 @@ describe('Request', () => {
     })
     describe('with mimeType param', () => {
       test('overrides default this.mimeType', () => {
-        let override = 'text/plain'
+        const override = 'text/plain'
 
         expect(new Request(uri, override).mimeType).toEqual(override)
       })
@@ -45,7 +45,7 @@ describe('Request', () => {
       restoreConsole()
     })
     describe('when successful', () => {
-      let expectedBody = '{"it": "worked"}'
+      const expectedBody = '{"it": "worked"}'
 
       beforeAll(() => {
         request.agent = new AgentSuccessFake(expectedBody)
@@ -59,8 +59,8 @@ describe('Request', () => {
       })
     })
     describe('when failure', () => {
-      let errorMessage = 'http error what what'
-      let logSpy = jest.spyOn(request.logger, 'error')
+      const errorMessage = 'http error what what'
+      const logSpy = jest.spyOn(request.logger, 'error')
 
       beforeAll(() => {
         request.agent = new AgentFailureFake(errorMessage)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   broker:
     image: rmohr/activemq
     ports:
-      - 61616:61616
       - 61613:61613
       - 8161:8161
   platform:
@@ -12,6 +11,8 @@ services:
       TRELLIS_BASE_URL: http://platform:8080
       TRELLIS_LOGGING_LEVEL: INFO
       TRELLIS_CONSOLE_LOGGING_THRESHOLD: INFO
+      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-us-west-2_CGd9Wq136}
+      AWS_REGION: ${AWS_REGION:-us-west-2}
     ports:
       - 8080:8080
       - 8081:8081
@@ -25,7 +26,6 @@ services:
     environment:
       INDEX_HOST: search
       BROKER_HOST: broker
-    command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -timeout 3m npm start
     depends_on:
       - broker
       - search

--- a/package-lock.json
+++ b/package-lock.json
@@ -859,7 +859,6 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
       "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -987,7 +986,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -995,8 +993,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1042,14 +1039,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-eslint": {
       "version": "10.0.1",
@@ -1212,7 +1207,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1224,9 +1218,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
       "dev": true
     },
     "boxen": {
@@ -1435,8 +1429,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "1.1.3",
@@ -1728,14 +1721,12 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-      "dev": true
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1790,7 +1781,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1971,7 +1961,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -2214,9 +2203,9 @@
       }
     },
     "eslint-takeoff": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-takeoff/-/eslint-takeoff-0.0.1.tgz",
-      "integrity": "sha512-8bBDd1j5O0fgrmp1dL9+WyCK4bPIPE/J6OOqyvhTZvMTzAzoPzIe8Suhnlvmdj8cyzBowjusj8OpX2Ry2q9FWw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-takeoff/-/eslint-takeoff-0.0.3.tgz",
+      "integrity": "sha512-gKI7Ym9Rhiq42cXNuIodqXSIORtaYn/PB/tyLhpmSQvuUn8LeP+OFRQFOb+IAJ390Wu1GX1F7O21RaAKcvzKCg==",
       "dev": true,
       "requires": {
         "caporal": "^0.10.0",
@@ -2418,8 +2407,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2521,8 +2509,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
       "version": "0.1.8",
@@ -2533,14 +2520,12 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2704,8 +2689,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
@@ -2757,8 +2741,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2779,14 +2762,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2801,20 +2782,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2931,8 +2909,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2944,7 +2921,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2959,7 +2935,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2967,14 +2942,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2993,7 +2966,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3074,8 +3046,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3087,7 +3058,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3173,8 +3143,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3210,7 +3179,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3230,7 +3198,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3274,14 +3241,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3332,7 +3297,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3419,26 +3383,17 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3450,14 +3405,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -3530,6 +3483,11 @@
         }
       }
     },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+    },
     "home-or-tmp": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
@@ -3564,7 +3522,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3974,8 +3931,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3995,6 +3951,14 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4010,8 +3974,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "2.1.1",
@@ -4052,9 +4015,9 @@
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-      "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
         "append-transform": "^1.0.0"
@@ -4076,16 +4039,38 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-      "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.3",
-        "make-dir": "^1.3.0",
-        "supports-color": "^6.0.0"
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
+        "istanbul-lib-coverage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -4119,12 +4104,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-      "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
+      "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.0"
+        "handlebars": "^4.1.2"
       }
     },
     "jest": {
@@ -5063,6 +5048,16 @@
         }
       }
     },
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -5076,9 +5071,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -5088,8 +5083,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "11.12.0",
@@ -5168,14 +5162,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5186,8 +5178,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.1.0",
@@ -5210,7 +5201,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -5591,6 +5581,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5731,8 +5727,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -6058,8 +6053,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
@@ -6206,8 +6200,7 @@
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-      "dev": true
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "pstree.remy": {
       "version": "1.1.6",
@@ -6228,8 +6221,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.6.0",
@@ -6446,7 +6438,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6473,20 +6464,17 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -6592,8 +6580,7 @@
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rxjs": {
       "version": "6.4.0",
@@ -6621,8 +6608,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "3.1.0",
@@ -7011,7 +6997,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7499,6 +7484,21 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+        }
+      }
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -7543,7 +7543,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7551,8 +7550,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -7570,16 +7568,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
+      "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7792,7 +7797,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -7845,8 +7849,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "3.1.2",
@@ -7871,7 +7874,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -7885,6 +7887,25 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "wait-on": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.2.0.tgz",
+      "integrity": "sha512-QUGNKlKLDyY6W/qHdxaRlXUAgLPe+3mLL/tRByHpRNcHs/c7dZXbu+OnJWGNux6tU1WFh/Z8aEwvbuzSAu79Zg==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "joi": "^13.0.0",
+        "minimist": "^1.2.0",
+        "request": "^2.88.0",
+        "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "elasticsearch": "^15.4.1",
     "stomp-client": "^0.9.0",
     "superagent": "^4.1.0",
-    "url-parse": "^1.4.4"
+    "url-parse": "^1.4.4",
+    "wait-on": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",
@@ -37,7 +38,7 @@
     "eslint": "^5.13.0",
     "eslint-plugin-jest": "^22.3.0",
     "eslint-plugin-node": "^8.0.1",
-    "eslint-takeoff": "0.0.1",
+    "eslint-takeoff": "0.0.3",
     "jest": "^24.1.0",
     "jest-mock-console": "^0.4.2",
     "nodemon": "^1.18.10"

--- a/runner.js
+++ b/runner.js
@@ -1,3 +1,27 @@
+import waitOn from 'wait-on'
+import Config from './src/config'
 import Pipeline from './src/pipeline'
 
-new Pipeline().run()
+const waitOptions = {
+  resources: [
+    `tcp:${Config.indexHost}:${Config.indexPort}`,
+    `tcp:${Config.brokerHost}:${Config.brokerPort}`
+  ],
+  log: true, // print status reports
+  interval: 1000, // check to see whether ES and MQ are up every 5s
+  timeout: 180000, // give up after 3m
+  tcpTimeout: 180000 // give up after 3m
+}
+
+const runner = async () => {
+  try {
+    await waitOn(waitOptions)
+  } catch(error) {
+    console.error(`dependencies did not start up in time: ${error}`)
+    return
+  }
+
+  new Pipeline().run()
+}
+
+runner()

--- a/src/config.js
+++ b/src/config.js
@@ -23,12 +23,16 @@ export default class Config {
     return process.env.DEFAULT_MIME_TYPE || 'application/ld+json'
   }
 
-  static get indexName() {
-    return process.env.INDEX_NAME || 'sinopia_index'
+  static get resourceIndexName() {
+    return process.env.RESOURCE_INDEX_NAME || 'sinopia_resources'
+  }
+
+  static get nonRdfIndexName() {
+    return process.env.NON_RDF_INDEX_NAME || 'sinopia_templates'
   }
 
   static get indexType() {
-    return process.env.INDEX_TYPE || 'sinopia_resource'
+    return process.env.INDEX_TYPE || 'sinopia'
   }
 
   static get indexHost() {
@@ -37,6 +41,14 @@ export default class Config {
 
   static get indexPort() {
     return process.env.INDEX_PORT || 9200
+  }
+
+  static get nonRdfTypeURI() {
+    return process.env.NON_RDF_TYPE_URI || 'http://www.w3.org/ns/ldp#NonRDFSource'
+  }
+
+  static get nonRdfMimeType() {
+    return process.env.NON_RDF_MIME_TYPE || 'application/json'
   }
 
   static get debug() {


### PR DESCRIPTION
Fixes #15
~~Blocked by trellis-ldp/trellis#398 (:man_dancing: trellis-ldp/trellis#399 :man_dancing:)~~

Also includes:

* Declare non-RDF mime type and LDP URI in config and make them overrideable
* Distinguish between resource and non-RDF index names in application configuration
* Pass (LDP) types explicitly from pipeline to indexer
* Make pipeline runner wait for dependent services using `wait-on` library rather than handling this in the docker-compose configuration (in preparation for handling start-up wait times in production-like environments)
* Add docker CMD as default action when starting container now that pipeline runner knows how to wait for services it depends on
* Add integration test coverage for non-RDF use case
* Add AWS/Cognito-related env variables to docker-compose configuration
* Bump up to node 10.15.x per sinopia_acl
* Prefer `const` over `let` for variables that do not vary

