### PR TITLE
Let Listener connect to TLS-enabled Stomp services

### DIFF
--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -16,6 +16,9 @@ describe('Config', () => {
     test('brokerPort has default value', () => {
       expect(Config.brokerPort).toEqual(61613)
     })
+    test('brokerTlsEnabled has default value', () => {
+      expect(Config.brokerTlsEnabled).toEqual(false)
+    })
     test('queueName has default value', () => {
       expect(Config.queueName).toEqual('/queue/trellis')
     })
@@ -55,6 +58,7 @@ describe('Config', () => {
         ROOT_NODE_IDENTIFIER: 'super_cool',
         BROKER_HOST: 'myhost',
         BROKER_PORT: 61616,
+        BROKER_TLS_ENABLED: 'true',
         QUEUE_NAME: '/topic/foobar',
         DEFAULT_MIME_TYPE: 'text/plain',
         RESOURCE_INDEX_NAME: 'test',
@@ -81,6 +85,9 @@ describe('Config', () => {
     })
     test('brokerPort has overridden value', () => {
       expect(Config.brokerPort).toEqual(61616)
+    })
+    test('brokerTlsEnabled has overridden value', () => {
+      expect(Config.brokerTlsEnabled).toEqual(true)
     })
     test('queueName has overridden value', () => {
       expect(Config.queueName).toEqual('/topic/foobar')

--- a/__tests__/Logger.test.js
+++ b/__tests__/Logger.test.js
@@ -25,7 +25,7 @@ describe('Logger', () => {
     })
     describe('with debug set to false', () => {
       beforeAll(() => {
-        Config.debug =  false
+        Config.debug = false
       })
       test('console.debug is not called', () => {
         logger.debug(testMessage)

--- a/src/Config.js
+++ b/src/Config.js
@@ -21,6 +21,12 @@ export default class Config {
     return process.env.BROKER_PORT || 61613
   }
 
+  static get brokerTlsEnabled() {
+    if (process.env.BROKER_TLS_ENABLED === 'true')
+      return true
+    return false
+  }
+
   static get queueName() {
     return process.env.QUEUE_NAME || '/queue/trellis'
   }

--- a/src/Listener.js
+++ b/src/Listener.js
@@ -4,8 +4,15 @@ import Logger from './Logger'
 
 export default class Listener {
   constructor() {
+    const stompOptions = {
+      host: Config.brokerHost,
+      port: Config.brokerPort
+    }
+    if (Config.brokerTlsEnabled)
+      stompOptions.tls = true
+
+    this.client = new Stomp(stompOptions)
     this.logger = new Logger()
-    this.client = new Stomp(Config.brokerHost, Config.brokerPort)
   }
 
   /**


### PR DESCRIPTION
Refs LD4P/sinopia_indexing_pipeline#18

Use a new config value to turn this on. Default is off. New environment variable is `BROKER_TLS_ENABLED`.