### PR TITLE
Specify ElasticSearch URL instead of host and port

### DIFF
--- a/__tests__/Config.test.js
+++ b/__tests__/Config.test.js
@@ -40,11 +40,8 @@ describe('Config', () => {
     test('indexType has default value', () => {
       expect(Config.indexType).toEqual('sinopia')
     })
-    test('indexHost has default value', () => {
-      expect(Config.indexHost).toEqual('localhost')
-    })
-    test('indexPort has default value', () => {
-      expect(Config.indexPort).toEqual(9200)
+    test('indexUrl has default value', () => {
+      expect(Config.indexUrl).toEqual('http://localhost:9200')
     })
     test('nonRdfTypeURI has default value', () => {
       expect(Config.nonRdfTypeURI).toEqual('http://www.w3.org/ns/ldp#NonRDFSource')
@@ -72,8 +69,7 @@ describe('Config', () => {
         RESOURCE_INDEX_NAME: 'test',
         INDEX_TYPE: 'other',
         NON_RDF_INDEX_NAME: 'test2',
-        INDEX_HOST: 'otherhost',
-        INDEX_PORT: 9300,
+        INDEX_URL: 'https://otherhost:9300',
         NON_RDF_TYPE_URI: 'http://foo.example.org/bar',
         NON_RDF_MIME_TYPE: 'text/plain',
         DEBUG: false
@@ -118,11 +114,8 @@ describe('Config', () => {
     test('indexType has overridden value', () => {
       expect(Config.indexType).toEqual('other')
     })
-    test('indexHost has overridden value', () => {
-      expect(Config.indexHost).toEqual('otherhost')
-    })
-    test('indexPort has overridden value', () => {
-      expect(Config.indexPort).toEqual(9300)
+    test('indexUrl has overridden value', () => {
+      expect(Config.indexUrl).toEqual('https://otherhost:9300')
     })
     test('nonRdfTypeURI has overridden value', () => {
       expect(Config.nonRdfTypeURI).toEqual('http://foo.example.org/bar')

--- a/__tests__/Indexer.test.js
+++ b/__tests__/Indexer.test.js
@@ -17,9 +17,8 @@ describe('Indexer', () => {
   const objectTypes = ['http://www.w3.org/ns/ldp#BasicContainer']
 
   describe('constructor()', () => {
-    it('creates a client with a hostname', () => {
-      const host = `${Config.indexHost}:${Config.indexPort}`
-      expect(indexer.client.transport._config.host).toEqual(host)
+    it('creates a client with the configured endpoint URL', () => {
+      expect(indexer.client.transport._config.host).toEqual(Config.indexUrl)
     })
     it('creates a logger', () => {
       expect(indexer.logger).toBeInstanceOf(Logger)

--- a/__tests__/Pipeline.integration.js
+++ b/__tests__/Pipeline.integration.js
@@ -4,7 +4,7 @@ import Config from '../src/Config'
 
 describe('integration tests', () => {
   const client = new elasticsearch.Client({
-    host: `${Config.indexHost}:${Config.indexPort}`,
+    host: Config.indexUrl,
     log: 'warning'
   })
   const resourceSlug = 'stanford12345'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     build:
       context: .
     environment:
-      INDEX_HOST: search
+      INDEX_URL: http://search:9200
       BROKER_HOST: broker
     depends_on:
       - broker
@@ -34,7 +34,7 @@ services:
     build:
       context: .
     environment:
-      INDEX_HOST: search
+      INDEX_URL: http://search:9200
       BROKER_HOST: broker
       INSIDE_CONTAINER: 'true'
     command: dockerize -wait tcp://broker:61613 -wait tcp://search:9200 -wait tcp://platform:8080 -timeout 3m npm run integration
@@ -45,7 +45,7 @@ services:
       context: .
     environment:
       TRELLIS_BASE_URL: http://platform:8080
-      INDEX_HOST: search
+      INDEX_URL: http://search:9200
       BROKER_HOST: broker
       INSIDE_CONTAINER: 'true'
     command: bin/reindex

--- a/reindex.js
+++ b/reindex.js
@@ -5,7 +5,7 @@ import Waiter from './src/Waiter'
 const waitOptions = {
   resources: [
     Config.platformUrl,
-    `tcp:${Config.indexHost}:${Config.indexPort}`
+    Config.indexUrl
   ]
 }
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -55,12 +55,8 @@ export default class Config {
     return process.env.INDEX_TYPE || 'sinopia'
   }
 
-  static get indexHost() {
-    return process.env.INDEX_HOST || 'localhost'
-  }
-
-  static get indexPort() {
-    return process.env.INDEX_PORT || 9200
+  static get indexUrl() {
+    return process.env.INDEX_URL || 'http://localhost:9200'
   }
 
   static get nonRdfTypeURI() {

--- a/src/Indexer.js
+++ b/src/Indexer.js
@@ -6,7 +6,7 @@ import Logger from './Logger'
 export default class Indexer {
   constructor() {
     this.client = new elasticsearch.Client({
-      host: `${Config.indexHost}:${Config.indexPort}`,
+      host: Config.indexUrl,
       log: 'warning'
     })
     this.logger = new Logger()

--- a/src/Waiter.js
+++ b/src/Waiter.js
@@ -6,7 +6,8 @@ export default class Waiter {
   constructor(options = {}) {
     this.options = {
       resources: [
-        `tcp:${Config.indexHost}:${Config.indexPort}`,
+        // indexUrl begins with `http[s]`, so the `tcp:` prefix is not needed
+        Config.indexUrl,
         `tcp:${Config.brokerHost}:${Config.brokerPort}`
       ],
       log: true, // print status reports


### PR DESCRIPTION
Refs #18

For two reasons:
1. We never use the port separate from the host;
2. More importantly: we need a fully qualified URL (w/ protocol) to both connect to ElasticSearch over both HTTP and HTTPS, *and* to have the `wait-on` library wait on it.