### PR TITLE
Index titles and subtitles using completion suggester

### DIFF
--- a/__mocks__/ClientSuccessFake.js
+++ b/__mocks__/ClientSuccessFake.js
@@ -1,5 +1,5 @@
 export default class ClientSuccessFake {
-  constructor() {
+  constructor(exists=false) {
     this.indices = {
       delete: () => {
         return new Promise((resolve, _reject) => {
@@ -13,7 +13,7 @@ export default class ClientSuccessFake {
       },
       exists: () => {
         return new Promise((resolve, _reject) => {
-          return resolve(false)
+          return resolve(exists)
         })
       },
       putMapping: () => {

--- a/__tests__/Indexer.test.js
+++ b/__tests__/Indexer.test.js
@@ -66,8 +66,12 @@ describe('Indexer', () => {
         id: '12345',
         body: {
           document: json,
+          author: [],
+          subject: [],
+          subtitle: ['A Tragic Tale about a Prince of Denmark'],
+          'subtitle-suggest': ['a', 'tragic', 'tale', 'about', 'a', 'prince', 'of', 'denmark'],
           title: ['Hamlet'],
-          subtitle: ['A Tragic Tale about a Prince of Denmark']
+          'title-suggest': ['hamlet'],
         }
       })
     })
@@ -227,6 +231,21 @@ describe('Indexer', () => {
 
   describe('setupIndices()', () => {
     const logSpy = jest.spyOn(indexer.logger, 'error')
+
+    describe('when indexes already exist', () => {
+      const clientMock = new ClientSuccessFake(true)
+      const createSpy = jest.spyOn(clientMock.indices, 'create')
+
+      beforeEach(() => {
+        indexer.client = clientMock
+      })
+
+      it('skips creating them', async () => {
+        await indexer.setupIndices()
+        expect(createSpy).not.toHaveBeenCalled()
+        expect(logSpy).not.toHaveBeenCalled()
+      })
+    })
 
     describe('when successful', () => {
       const clientMock = new ClientSuccessFake()

--- a/__tests__/Pipeline.integration.js
+++ b/__tests__/Pipeline.integration.js
@@ -1,6 +1,7 @@
 import config from 'config'
 import elasticsearch from 'elasticsearch'
 import superagent from 'superagent'
+import Indexer from '../src/Indexer'
 
 describe('integration tests', () => {
   const client = new elasticsearch.Client({
@@ -12,20 +13,11 @@ describe('integration tests', () => {
   const nonRdfSlug = 'resourceTemplate:foo123:Something:Excellent'
   const nonRdfBody = { foo: 'bar', baz: 'quux' }
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
-  const createIndexIfAbsent = async indexName => {
-    const indexExists = await client.indices.exists({ index: indexName })
-    if (!indexExists) {
-      return client.indices.create({
-        index: indexName
-      })
-    }
-    return null
-  }
 
   beforeAll(async () => {
-    await createIndexIfAbsent(config.get('resourceIndexName'))
-    await createIndexIfAbsent(config.get('nonRdfIndexName'))
+    await new Indexer().recreateIndices()
   })
+
   afterAll(async () => {
     // Remove test resources from indices
     await client.delete({
@@ -39,6 +31,7 @@ describe('integration tests', () => {
       id: nonRdfSlug
     })
   })
+
   test('resource index is clear of test document', () => {
     return client.search({
       index: config.get('resourceIndexName'),
@@ -56,6 +49,7 @@ describe('integration tests', () => {
       expect(response.hits.total).toEqual(0)
     })
   })
+
   test('resource template index is clear of test document', () => {
     return client.search({
       index: config.get('nonRdfIndexName'),
@@ -73,10 +67,11 @@ describe('integration tests', () => {
       expect(response.hits.total).toEqual(0)
     })
   })
+
   test('new Trellis resource is indexed', async () => {
     superagent.post(config.get('platformUrl'))
       .type('application/ld+json')
-      .send(`{ "@context": { "dcterms": "http://purl.org/dc/terms/" }, "@id": "", "dcterms:title": "${resourceTitle}" }`)
+      .send(`{ "@context": { "mainTitle": { "@id": "http://id.loc.gov/ontologies/bibframe/mainTitle" } }, "@id": "", "mainTitle": [{ "@value": "${resourceTitle}", "@language": "en" }] }`)
       .set('Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
       .set('Slug', resourceSlug)
       .then(res => res.body)
@@ -100,9 +95,10 @@ describe('integration tests', () => {
       expect(response.hits.total).toEqual(1)
       const firstHit = response.hits.hits[0]
       expect(firstHit._source.document['@id']).toEqual(`${config.get('platformUrl')}/${resourceSlug}`)
-      expect(firstHit._source.document.title).toEqual(resourceTitle)
+      expect(firstHit._source.title[0]).toEqual(resourceTitle)
     })
   })
+
   test('new Trellis resource template is indexed', async () => {
     superagent.post(config.get('platformUrl'))
       .type('application/json')
@@ -133,6 +129,7 @@ describe('integration tests', () => {
       expect(firstHit._source.document.baz).toEqual('quux')
     })
   })
+
   test('deleted Trellis resource is removed from resource index', async () => {
     superagent.delete(`${config.get('platformUrl')}/${resourceSlug}`)
       .then(res => res.body)
@@ -156,6 +153,7 @@ describe('integration tests', () => {
       expect(response.hits.total).toEqual(0)
     })
   })
+
   test('deleted Trellis resource template is removed from resource template index', async () => {
     superagent.delete(`${config.get('platformUrl')}/${nonRdfSlug}`)
       .then(res => res.body)

--- a/config/default.js
+++ b/config/default.js
@@ -17,7 +17,18 @@ module.exports = {
   indexUrl: process.env.INDEX_URL || 'http://localhost:9200',
   indexFieldMappings: process.env.INDEX_FIELD_MAPPINGS
     ? JSON.parse(process.env.INDEX_FIELD_MAPPINGS)
-    : { title: { type: 'text', path: '$..mainTitle' }, subtitle: { type: 'text', path: '$..subtitle' } },
+    : {
+      title: {
+        type: 'text',
+        path: '$..mainTitle',
+        autosuggest: true
+      },
+      subtitle: {
+        type: 'text',
+        path: '$..subtitle',
+        autosuggest: true
+      }
+    },
   nonRdfTypeURI: process.env.NON_RDF_TYPE_URI || 'http://www.w3.org/ns/ldp#NonRDFSource',
   nonRdfMimeType: process.env.NON_RDF_MIME_TYPE || 'application/json',
   debug:  process.env.DEBUG !== undefined ? process.env.DEBUG : true

--- a/config/test.js
+++ b/config/test.js
@@ -1,3 +1,24 @@
 module.exports = {
   // Placeholder to prevent https://github.com/lorenwest/node-config/wiki/Strict-Mode#node_env-value-of-node_env-did-not-match-any-deployment-config-file-names
+  indexFieldMappings: {
+    title: {
+      type: 'text',
+      path: '$..mainTitle',
+      autosuggest: true,
+    },
+    subtitle: {
+      type: 'text',
+      path: '$..subtitle',
+      autosuggest: true,
+    },
+    author: {
+      type: 'text',
+      path: '$..author',
+      autosuggest: false,
+    },
+    subject: {
+      type: 'text',
+      path: '$..subject',
+    },
+  },
 }


### PR DESCRIPTION
Fixes #25

Includes:
* Add suggest fields to index mappings, using completion suggesters, and to the `Indexer.buildIndexEntryFrom()` function
* Add `autosuggest` field to `indexFieldMappings` in config, allowing us to control suggest fields without touching code in the future
* Add suggest search example to `search.js` test/inspection tool (also used to verify the work in this branch actually works)
* In the pipeline integration test, reflect data structure the code expects (needed updating)
* Use `Indexer.recreateIndices()` in pipeline integration test in favor of custom delete/create logic in the test
* Add arg to `ClientSuccessFake` constructor allowing `exists()` behavior to vary
* Add missing test coverage for `Indexer.setupIndices()` (not related to typeahead indexing, but rather opportunistic debt payment)