### PR TITLE
Updated eslint-utils to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2126,10 +2126,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^5.13.0",
     "eslint-plugin-jest": "^22.3.0",
     "eslint-plugin-node": "^8.0.1",
+    "eslint-utils": ">=1.4.1",
     "jest": "^24.1.0",
     "jest-mock-console": "^0.4.2",
     "nodemon": "^1.18.10"


### PR DESCRIPTION
Fixes this security issue Github [security alert](https:/github.com/mysticatea/eslint-utils/security/advisories/GHSA-3gx7-xhv7-5mx3)