### PR TITLE
minor fix to integration test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ npm test
 To run the integration tests, they must be invoked independent of the unit tests:
 
 ```shell
-$ INSIDE_CONTAINER=true npm run integration
+$ npm run integration
 ```
 
 **NOTE**: The `pipeline` `docker-compose` service must be running for the integration tests to pass.


### PR DESCRIPTION
i found the manual inclusion of the `INSIDE_CONTAINER=true` env var to be unnecessary/counterproductive when invoking the integration tests directly from the command line on my laptop (and indeed, running the tests that way is not running them in a container).  if running per the old instructions, i'd get errors like `getaddrinfo ENOTFOUND platform platform:8080`.

the `docker-compose run integration` command described below the modified instruction will already set that env var (because `INSIDE_CONTAINER` is correctly hardcoded to `true` for the `integration` container in `docker-compose.yml`).