### PR TITLE
add another search test specifically for case sensitivity

### DIFF
--- a/__tests__/Pipeline.integration.js
+++ b/__tests__/Pipeline.integration.js
@@ -105,6 +105,7 @@ describe('integration tests', () => {
       { phrase: 'cool title', totalHits: 1},
       { phrase: 'cöôl title', totalHits: 1},
       { phrase: 'COOL title', totalHits: 1},
+      { phrase: 'COOL TITLE', totalHits: 1},
       { phrase: 'cool', totalHits: 1},
       { phrase: 'title', totalHits: 1},
       { phrase: 'coooool tiiiitle', totalHits: 0},


### PR DESCRIPTION
this test failed when i tried to add it as part of #64.  now that #77 has been merged, it works (or at least, it worked for me locally, but only after i pulled the changes from #77).