### PR TITLE
Fix reindexing, opportunistic async cleanup

### DIFF
--- a/__mocks__/RequestTypedSuccessFake.js
+++ b/__mocks__/RequestTypedSuccessFake.js
@@ -3,8 +3,24 @@ export default class RequestTypedSuccessFake {
     return new Promise((resolve, _reject) => {
       return resolve({
         body: {
-          // TODO: change this when ready to test recursive Crawler.request() function
-          contains: []
+          '@graph': [
+            {
+              '@id': '_:b0',
+              '@type': [
+                'prov:Activity',
+                'as:Create'
+              ],
+              'atTime': '2019-10-23T23:40:48.529Z',
+              'wasAssociatedWith': 'http://www.trellisldp.org/ns/trellis#AnonymousAgent'
+            },
+            {
+              '@id': 'http://platform.test:8080/repository',
+              'label': 'Sinopia Repository Container',
+              // TODO: change this when ready to test recursive Crawler.request() function
+              'contains': [],
+              'wasGeneratedBy': '_:b0'
+            }
+          ]
         }
       })
     })

--- a/__tests__/Crawler.test.js
+++ b/__tests__/Crawler.test.js
@@ -146,8 +146,8 @@ describe('Crawler', () => {
 
       it('executes the callback', async () => {
         await crawler.request(uri, callback)
-
-        expect(callback).toHaveBeenCalledWith({ contains: [] }, uri, ['type1', 'type2'])
+        const successRespBody = (await ((new RequestTypedSuccessFake()).response())).body
+        expect(callback).toHaveBeenCalledWith(successRespBody, uri, ['type1', 'type2'])
       })
       // TODO: Come up with a strategy for better testing this recursive function
       it.todo('makes one request per contained resource ("child")')

--- a/__tests__/Pipeline.integration.js
+++ b/__tests__/Pipeline.integration.js
@@ -196,13 +196,14 @@ describe('integration tests', () => {
       expect(response.hits.total).toEqual(0)
     })
 
-    // TODO: seems like some calls made from within Reindexer().reindex() don't necessarily await
-    // as maybe they could to allow reindex to settle iff all its spawned requests have settled, hence
-    // sleep below.  should await logic in there get tightened up?
+    // The .reindex() code should work such that the Promise it returns will
+    // settle iff the Promises it spawns have all settled (e.g. the trellis crawl,
+    // and the indexing requests spawned by the callback the crawl uses).
+    // If things change and cause that assumption not to hold any longer, change the
+    // test to do as is done above for the regular pipeline, and follow this with e.g.
+    // `await sleep(4900)` (the pipeline listener doesn't await any of the indexing requests
+    // it spawns, because it does nothing itself with those results).
     await new Reindexer().reindex()
-
-    // Give the reindex requests a chance to finish
-    await sleep(4900)
 
     await Promise.all([...Array(resourceCount).keys()].map(i => {
       const identifier = `repository/${reindexingResourceSlug}_${i}`

--- a/__tests__/Pipeline.integration.js
+++ b/__tests__/Pipeline.integration.js
@@ -2,14 +2,17 @@ import config from 'config'
 import elasticsearch from 'elasticsearch'
 import superagent from 'superagent'
 import Indexer from '../src/Indexer'
+import Reindexer from '../src/Reindexer'
 
 describe('integration tests', () => {
   const client = new elasticsearch.Client({
     host: config.get('indexUrl'),
     log: 'warning'
   })
-  const resourceSlug = 'stanford12345'
+  const resourceSlug = `stanford_${Math.floor(Math.random() * 10000)}`
   const resourceTitle = 'A cøol tītlé'
+  const reindexingResourceTitle = 'Title for reindexing'
+  const reindexingResourceSlug = `stanford_re_${Math.floor(Math.random() * 10000)}`
   const nonRdfSlug = 'resourceTemplate:foo123:Something:Excellent'
   const nonRdfBody = { foo: 'bar', baz: 'quux' }
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
@@ -32,7 +35,7 @@ describe('integration tests', () => {
     })
   })
 
-  jest.setTimeout(7500)
+  jest.setTimeout(15000)
 
   test('resource index is clear of test document', () => {
     return client.search({
@@ -126,6 +129,100 @@ describe('integration tests', () => {
         expect([phrase, response.hits.total]).toEqual([phrase, totalHits])
       })
     }
+  })
+
+  test('Trellis resources are re-indexed', async () => {
+    // if not already present, create the base repository container as we'd have in practice, so there's some structure to crawl
+    await superagent.head(`${config.get('platformUrl')}/repository`)
+      .catch(async _err => {
+        await superagent.post(`${config.get('platformUrl')}`)
+          .type('application/ld+json')
+          .send('{ "@context": { "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "ldp": "http://www.w3.org/ns/ldp#" }, "@id": "", "@type": [ "ldp:Container", "ldp:BasicContainer" ], "rdfs:label": "Sinopia LDP Server" }')
+          .set('Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
+          .set('Slug', 'repository')
+          .then(res => res.body)
+          .catch(err => { console.dir(err); throw err })
+      })
+
+    const resourceCount = 5
+    await Promise.all([...Array(resourceCount).keys()].map(i =>
+      superagent.post(`${config.get('platformUrl')}/repository`)
+        .type('application/ld+json')
+        .send(`{ "@context": { "mainTitle": { "@id": "http://id.loc.gov/ontologies/bibframe/mainTitle" } }, "@id": "", "mainTitle": [{ "@value": "${reindexingResourceTitle} ${i}", "@language": "en" }] }`)
+        .set('Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
+        .set('Slug', `${reindexingResourceSlug}_${i}`)
+        .then(res => res.body)
+        .catch(err => { console.dir(err); throw err })
+    ))
+
+    // Give the pipeline a chance to run
+    await sleep(4900)
+
+    await Promise.all([...Array(resourceCount).keys()].map(i => {
+      const identifier = `repository/${reindexingResourceSlug}_${i}`
+      return client.search({
+        index: config.get('resourceIndexName'),
+        type: config.get('indexType'),
+        body: {
+          query: {
+            term: {
+              _id: {
+                value: identifier
+              }
+            }
+          }
+        }
+      }).then(response => {
+        // including phrase makes it easier to find the one that fails the test, should the test fail
+        expect([identifier, response.hits.total]).toEqual([identifier, response.hits.total])
+      })
+    }))
+
+    // simulate indexing catastrophe
+    await new Indexer().recreateIndices()
+
+    // sanity check simulated catastrophe
+    await client.search({
+      index: config.get('resourceIndexName'),
+      type: config.get('indexType'),
+      body: {
+        query: {
+          match: {
+            title: '*'
+          }
+        }
+      }
+    }).then(response => {
+      expect(response.hits.total).toEqual(0)
+    })
+
+    // TODO: seems like some calls made from within Reindexer().reindex() don't necessarily await
+    // as maybe they could to allow reindex to settle iff all its spawned requests have settled, hence
+    // sleep below.  should await logic in there get tightened up?
+    await new Reindexer().reindex()
+
+    // Give the reindex requests a chance to finish
+    await sleep(4900)
+
+    await Promise.all([...Array(resourceCount).keys()].map(i => {
+      const identifier = `repository/${reindexingResourceSlug}_${i}`
+      return client.search({
+        index: config.get('resourceIndexName'),
+        type: config.get('indexType'),
+        body: {
+          query: {
+            term: {
+              _id: {
+                value: identifier
+              }
+            }
+          }
+        }
+      }).then(response => {
+        // including phrase makes it easier to find the one that fails the test, should the test fail
+        expect([identifier, response.hits.total]).toEqual([identifier, response.hits.total])
+      })
+    }))
   })
 
   test('new Trellis resource template is not indexed', async () => {

--- a/src/Indexer.js
+++ b/src/Indexer.js
@@ -23,7 +23,7 @@ export default class Indexer {
    * @param {Object} json - Object to be indexed
    * @param {string} uri - URI of object to be indexed
    * @param {string} types - one or more LDP type URIs
-   * @returns {?boolean} true if successful; null if not
+   * @returns {Promise} resolves to true if successful; null if not
    */
   index(json, uri, types) {
     const index = this.indexNameFrom(types)
@@ -53,7 +53,7 @@ export default class Indexer {
    * @param {string} uri - URI of object to be indexed
    * @param {string} types - one or more LDP type URIs
    * @returns {?boolean} true if successful; null if not
-   * @param {string} types - one or more LDP type URIs
+   * @param {Promise} resolves to types - one or more LDP type URIs
    */
   delete(uri, types) {
     return this.client.delete({
@@ -139,7 +139,7 @@ export default class Indexer {
 
   /**
    * Remove and recreate all known indices
-   * @returns {null}
+   * @returns {Promise} resolves to null upon completion (errors, if any, are logged)
    */
   async recreateIndices() {
     try {

--- a/src/Reindexer.js
+++ b/src/Reindexer.js
@@ -17,7 +17,8 @@ export default class Reindexer {
     await this.crawler.crawl((resource, uri, types) => {
       this.logger.debug(`found resource for ${uri} with types: ${types}`)
       try {
-        this.indexer.index(resource, uri, types)
+        // pass along the .index() returned Promise in case caller wants to wait on it
+        return this.indexer.index(resource, uri, types)
       } catch(error) {
         this.logger.error(`error reindexing ${uri}: ${error}`)
       }


### PR DESCRIPTION
* **main goal**: fix Crawler logic for parsing `contains` relationships (first commit)
  * new integration test to exercise reindexing, minor tweaks to integration tests to increase max timeout and make tests more re-runnable locally w/o pruning volumes.
  * reflect expected structure in unit test fake.
  * also: the integration tests turn out to exercise both of the `contains` structures that the crawler is coded to parse.  the `/` container, having never been updated by the integration test, has no provenance activity for trellis to return, and so still returns info about contained resources by way of a single flat `'contains'` field directly in the response body.  the `/repository` container, however, has the `'contains'` as a list field in an object in the `'@graph'` list in the response body.
    * the unit tests don't yet exercise the crawler recursion 😞  (wanted to get something up asap, and integration tests seemed like the higher payoff thing to concentrate on)


* _while i'm here..._ tighten up `await` logic and comments for `Crawler.js`, `Indexer.js`, and `Reindexer.js` (second commit)
  * `Indexer.js`: note where `Promise` is returned by function, with expected type for what `Promise` resolves to (instead of conflating function return value/type with resolution value/type of returned `Promise`).
  * `Reindexer.js`: have callback pass along the `Promise` from `this.indexer.index()` as callback return value.
  * `Crawler.js`: `Crawler.request()` should settle iff the `Promise`s it has spawned have settled (`onResource` callback and all recursion through children).  but also, use `Promise.all` to maximize concurrency since callback and child recursion can all happen simultaneously.
  * `Pipeline.integration.js`: no longer need to sleep after call to `Reindexer().reindex()`, since it will only settle when all the operations it has spawned have settled.  update comment explaining why, and how to adjust test if that shifts.

since i worried it might be seen as unnecessary and/or counter to how we actually want to operate, i left the async touchups as a separate (easy to remove) commit.  tests pass for the first commit alone as well as the touchup commit.  still, i think it's an improvement:  the documentation about return types is a little more honest, `reindex()` calls will settle iff all spawned calls have settled (and so a caller can just `await new Reindexer().reindex()` as is done in the integration test), but the regular indexing pipeline still doesn't bother to wait on any of the async calls it spawns (because the error handling already happens in each indexing call, and the pipeline doesn't care beyond firing off the request).  also, the crawler code that coordinates recursion of trellis resources still tries to maximize concurrency by using `Promise.all` to manage the `Promise`s it spawns (as opposed to e.g. looping and `await`ing each one individually).

the second commit was only a couple hours of work, so no huge time investment lost if my thinking turned out to be off base there.

closes #84 (hopefully; also worked for me in my manual testing locally)