### PR TITLE
pin to version of ES client compatible with our deployed elasticsearch instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2868,9 +2868,9 @@
       }
     },
     "@elastic/elasticsearch": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.14.0.tgz",
-      "integrity": "sha512-BlxqykcNtdBxo0mF7UQ1OsUxoVOOnEaeF70u2N4jpePih9paCOOotTWfFSDrtEw0TWv1CZlzCGD3TD5+8ASx8A==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
+      "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
       "requires": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@babel/runtime": "^7.15.3",
-    "@elastic/elasticsearch": "^7.13.0",
+    "@elastic/elasticsearch": "7.13.0",
     "@rdfjs/parser-jsonld": "^1.2.1",
     "config": "^3.3.6",
     "honeybadger": "^1.4.0",


### PR DESCRIPTION
correctly, this time (i had not noticed in #291 that the actual version in `package-lock.json` remained unchanged).