### PR TITLE
Add the image name to the docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   pipeline:
     build:
       context: .
+    image: ld4p/sinopia_indexing_pipeline:latest
     environment:
       INDEX_URL: http://search:9200
       BROKER_HOST: broker


### PR DESCRIPTION


## Why was this change made?
Then when you do `docker compose build pipeline`, it tags it appropriately


## How was this change tested?



## Which documentation and/or configurations were updated?



