### PR TITLE
Only index the first title.

### DIFF
--- a/__tests__/ResourceIndexer.test.js
+++ b/__tests__/ResourceIndexer.test.js
@@ -155,4 +155,69 @@ describe("ResourceIndexer", () => {
       })
     })
   })
+
+  describe("Resource with a title and variant title", () => {
+    const doc = {
+      data: [
+        {
+          "@id":
+            "https://api.development.sinopia.io/resource/860e40cb-8c63-4014-90f4-4682d25780a8",
+          "@type": ["http://id.loc.gov/ontologies/bibframe/Note"],
+          "http://sinopia.io/vocabulary/hasResourceTemplate": [
+            {
+              "@value": "resourceTemplate:bf2:Title:Note",
+            },
+          ],
+        },
+        {
+          "@id": "_:b1",
+          "@type": ["http://id.loc.gov/ontologies/bibframe/Title"],
+          "http://id.loc.gov/ontologies/bibframe/mainTitle": [
+            {
+              "@value": "Return",
+              "@language": "en",
+            },
+          ],
+        },
+        {
+          "@id": "_:b2",
+          "@type": ["http://id.loc.gov/ontologies/bibframe/VariantTitle"],
+          "http://id.loc.gov/ontologies/bibframe/mainTitle": [
+            {
+              "@value": "Returning",
+              "@language": "en",
+            },
+          ],
+        },
+      ],
+      bfAdminMetadataRefs: [],
+      bfInstanceRefs: [],
+      bfItemRefs: [],
+      bfWorkRefs: [],
+      group: "cornell",
+      types: ["http://id.loc.gov/ontologies/bibframe/Note"],
+      user: "sinopia-devs_client-tester",
+      timestamp: "2020-08-21T22:20:56.893Z",
+      templateId: "resourceTemplate:bf2:Title:Note",
+      id: "860e40cb-8c63-4014-90f4-4682d25780a8",
+      _id: "617c3e06efce030013d91fc3",
+      uri: "https://api.development.sinopia.io/resource/860e40cb-8c63-4014-90f4-4682d25780a8",
+      editGroups: ["stanford"],
+    }
+
+    it("ignores the variant title", async () => {
+      const dataset = await datasetFromJsonld(doc.data)
+      expect(await new ResourceIndexer(doc, dataset).index()).toEqual({
+        mongoId: "617c3e06efce030013d91fc3",
+        uri: "https://api.development.sinopia.io/resource/860e40cb-8c63-4014-90f4-4682d25780a8",
+        label: "Return",
+        text: ["resourceTemplate:bf2:Title:Note", "Return", "Returning"],
+        title: ["Return", "Returning"],
+        modified: "2020-08-21T22:20:56.893Z",
+        type: ["http://id.loc.gov/ontologies/bibframe/Note"],
+        group: "cornell",
+        editGroups: ["stanford"],
+      })
+    })
+  })
 })

--- a/src/ResourceIndexer.js
+++ b/src/ResourceIndexer.js
@@ -91,7 +91,7 @@ export default class {
         this.indexObject[fieldName] &&
         this.indexObject[fieldName].length > 0
       ) {
-        labelValues.push(this.indexObject[fieldName])
+        labelValues.push(this.indexObject[fieldName][0])
       }
     })
     this.indexObject["label"] =


### PR DESCRIPTION
closes #447

## Why was this change made?
To avoid indexing variant titles when a main title is present.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



